### PR TITLE
Update loki's default configuration example

### DIFF
--- a/grafana-loki/rootfs/etc/loki/default-config.yaml
+++ b/grafana-loki/rootfs/etc/loki/default-config.yaml
@@ -6,50 +6,34 @@ analytics:
 
 server: {}
 
-ingester:
-  lifecycler:
-    address: 127.0.0.1
-    ring:
-      kvstore:
-        store: inmemory
-      replication_factor: 1
-    final_sleep: 0s
-  chunk_idle_period: 1h
-  max_chunk_age: 1h
-  chunk_target_size: 1048576
-  chunk_retain_period: 30s
-  max_transfer_retries: 0
-  wal:
-    dir: /data/loki/wal
+common:
+  path_prefix: /data/loki
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
 
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
+    - from: 2025-06-21
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
 
 storage_config:
-  boltdb_shipper:
-    active_index_directory: /data/loki/boltdb-shipper-active
-    cache_location: /data/loki/boltdb-shipper-cache
-    cache_ttl: 24h
-    shared_store: filesystem
   filesystem:
-    directory: /data/loki/chunks
+    directory: /data/loki/tsdb-chunks
 
 compactor:
-  working_directory: /data/loki/boltdb-shipper-compactor
-  shared_store: filesystem
+  working_directory: /data/loki/tsdb-shipper-compactor
   retention_enabled: true
+  delete_request_store: filesystem
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   retention_period: ${RETENTION_PERIOD:29d}
-
-chunk_store_config:
-  max_look_back_period: 0s


### PR DESCRIPTION
Grafana Loki did an update to their storage engines and remove `boltdb`. This new example config uses the new `tsdb` by default.