### PR TITLE
Remove unsupported architectures and codenotary

### DIFF
--- a/grafana-loki/build.yaml
+++ b/grafana-loki/build.yaml
@@ -2,9 +2,6 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
   amd64: "ghcr.io/home-assistant/amd64-base:3.22"
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"

--- a/grafana-promtail/build.yaml
+++ b/grafana-promtail/build.yaml
@@ -2,9 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.8.3
   amd64: ghcr.io/hassio-addons/debian-base/amd64:7.8.3
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"

--- a/rclone/build.yaml
+++ b/rclone/build.yaml
@@ -1,17 +1,12 @@
 ---
 build_from:
-  i386: "ghcr.io/home-assistant/i386-base:3.22"
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
   amd64: "ghcr.io/home-assistant/amd64-base:3.22"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.22"
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.licenses: "MIT License"
-  org.opencontainers.image.title: 'Home Assistant Unofficial Add-on: rclone'
+  org.opencontainers.image.title: "Home Assistant Unofficial Add-on: rclone"
   org.opencontainers.image.url: https://github.com/bluemaex/home-assistant-addons
   org.opencontainers.image.source: https://github.com/bluemaex/home-assistant-addons/rclone
   org.opencontainers.image.documentation: https://github.com/bluemaex/home-assistant-addons/rclone/README.md

--- a/rclone/config.yaml
+++ b/rclone/config.yaml
@@ -8,8 +8,6 @@ description: |
 arch:
   - aarch64
   - amd64
-  - armv7
-  - i386
 image: "ghcr.io/bluemaex/ha-addons-rclone-{arch}"
 startup: once
 boot: manual

--- a/traefik/build.yaml
+++ b/traefik/build.yaml
@@ -2,15 +2,11 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
   amd64: "ghcr.io/home-assistant/amd64-base:3.22"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.22"
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.licenses: "MIT License"
-  org.opencontainers.image.title: 'Home Assistant Unofficial Add-on: traefik'
+  org.opencontainers.image.title: "Home Assistant Unofficial Add-on: traefik"
   org.opencontainers.image.url: https://github.com/bluemaex/home-assistant-addons
   org.opencontainers.image.source: https://github.com/bluemaex/home-assistant-addons/traefik
   org.opencontainers.image.documentation: https://github.com/bluemaex/home-assistant-addons/traefik/README.md

--- a/unpoller/build.yaml
+++ b/unpoller/build.yaml
@@ -2,10 +2,6 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
   amd64: "ghcr.io/home-assistant/amd64-base:3.22"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.22"
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"

--- a/victoriametrics/build.yaml
+++ b/victoriametrics/build.yaml
@@ -1,17 +1,12 @@
 ---
 build_from:
-  i386: "ghcr.io/home-assistant/i386-base:3.22"
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
   amd64: "ghcr.io/home-assistant/amd64-base:3.22"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.22"
-codenotary:
-  signer: homeassistant@blmx.de
-  base_image: notary@home-assistant.io
 labels:
   maintainer: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.authors: "bluemaex <homeassistant@blmx.de>"
   org.opencontainers.image.licenses: "MIT License"
-  org.opencontainers.image.title: 'Home Assistant Unofficial Add-on: victoriametrics'
+  org.opencontainers.image.title: "Home Assistant Unofficial Add-on: victoriametrics"
   org.opencontainers.image.url: https://github.com/bluemaex/home-assistant-addons
   org.opencontainers.image.source: https://github.com/bluemaex/home-assistant-addons/victoriametrics
   org.opencontainers.image.documentation: https://github.com/bluemaex/home-assistant-addons/victoriametrics/README.md

--- a/victoriametrics/config.yaml
+++ b/victoriametrics/config.yaml
@@ -7,8 +7,6 @@ description: |
 arch:
   - aarch64
   - amd64
-  - armv7
-  - i386
 image: "ghcr.io/bluemaex/ha-addons-victoriametrics-{arch}"
 startup: system
 url: https://github.com/bluemaex/home-assistant-addons/tree/master/victoriametrics


### PR DESCRIPTION
Removing deprecated codenotary fields from the images

Also removing architectures armv7 and i386 that are no longer supported as of Home Assistant 2025.12 (December 3, 2025).

Marking this as a major change mainly due to less supported architectures. No other code changes