### PR TITLE
feat(openbao): declarative audit devices with log rotation

### DIFF
--- a/openbao/DOCS.md
+++ b/openbao/DOCS.md
@@ -9,11 +9,11 @@ encryption-as-a-service for your homelab.
 On the very first start, the addon automatically:
 
 1. Creates data directories under `/data/openbao/`
-2. Generates the server configuration from your options
-3. Starts the OpenBao server
-4. **Initializes** the Raft storage backend (single key share, 1-of-1 threshold)
-5. Saves the root token and unseal key to `/data/openbao/init.json`
-6. **Unseals** the vault (if `auto_unseal: true`)
+1. Generates the server configuration from your options
+1. Starts the OpenBao server
+1. **Initializes** the Raft storage backend (single key share, 1-of-1 threshold)
+1. Saves the root token and unseal key to `/data/openbao/init.json`
+1. **Unseals** the vault (if `auto_unseal: true`)
 
 **After the first start, immediately back up `/data/openbao/init.json`.**
 This file contains your root token and unseal key. If lost, your secrets are
@@ -163,10 +163,8 @@ To enable TLS directly on OpenBao:
 1. Place your certificate files in `/ssl/openbao/`:
    - `fullchain.pem` — certificate chain
    - `privkey.pem` — private key
-
-2. Set `tls_disable: false` in the addon options
-
-3. Restart the addon
+1. Set `tls_disable: false` in the addon options
+1. Restart the addon
 
 With TLS enabled, use `https://<homeassistant-ip>:8200` for direct access.
 
@@ -227,7 +225,33 @@ ansible-galaxy collection install community.hashi_vault
 | `log_level` | `info` | Log verbosity level |
 | `auto_unseal` | `true` | Auto-unseal on startup using key from `init.json` |
 | `tls_disable` | `true` | Disable TLS (use a reverse proxy for encryption) |
+| `audit_stdout` | `true` | Audit log to the add-on log (and therefore journald) |
+| `audit_file` | `false` | Audit log to `/data/openbao/logs/audit.log`, rotated |
 | `env_vars` | `[]` | Extra environment variables for the OpenBao process |
+
+## Audit Logging
+
+OpenBao v2.3.2+ **refuses to create audit devices over the API**:
+
+```
+* cannot enable audit device via API; use declarative, config-based audit device management instead
+```
+
+So `bao audit enable …` will not work, and neither will Terraform's `vault_audit`
+resource. Audit devices are declared in the server configuration instead, which
+this add-on generates — hence the two options above.
+
+| Option | Sink | Fails closed? |
+| --- | --- | --- |
+| `audit_stdout` | add-on log → journald | No — `/dev/stdout` never touches the filesystem |
+| `audit_file` | `/data/openbao/logs/audit.log` | Yes, if the volume fills |
+
+**Read this before enabling `audit_file`.** OpenBao stops serving requests when no
+enabled audit device can record them — *"OpenBao will not respond to requests when
+no enabled audit devices can record them"*.
+
+Values in the log are HMAC-SHA256'd — the log shows *which* path was accessed, not
+the secret.
 
 ## Security Notes
 

--- a/openbao/Dockerfile
+++ b/openbao/Dockerfile
@@ -8,6 +8,6 @@ ARG USERNAME=openbao
 COPY rootfs /
 COPY --from=openbao-base /usr/bin/bao /usr/local/bin/bao
 
-RUN apk add --no-cache curl gomplate jq \
+RUN apk add --no-cache curl gomplate jq logrotate \
     && addgroup "${USERNAME}" \
     && adduser -S -G "${USERNAME}" "${USERNAME}"

--- a/openbao/config.yaml
+++ b/openbao/config.yaml
@@ -19,10 +19,14 @@ options:
   log_level: info
   auto_unseal: true
   tls_disable: true
+  audit_stdout: true
+  audit_file: false
   env_vars: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   auto_unseal: bool
   tls_disable: bool
+  audit_stdout: bool
+  audit_file: bool
   env_vars:
     - str

--- a/openbao/rootfs/etc/defaults/openbao.json.gotmpl
+++ b/openbao/rootfs/etc/defaults/openbao.json.gotmpl
@@ -1,4 +1,6 @@
 {{- $options := (ds "options") -}}
+{{- $auditStdout := index $options "audit_stdout" -}}
+{{- $auditFile := index $options "audit_file" -}}
 {
   "ui": true,
   "api_addr": "http{{ if not $options.tls_disable }}s{{ end }}://0.0.0.0:8200",
@@ -24,5 +26,32 @@
       "node_id": "homeassistant"
     }
   },
+{{- if or $auditStdout $auditFile }}
+  "audit": [
+{{- if $auditStdout }}
+    {
+      "file": {
+        "to-stdout": {
+          "description": "audit -> addon log -> journald",
+          "options": { "file_path": "/dev/stdout" }
+        }
+      }
+    }{{ if $auditFile }},{{ end }}
+{{- end }}
+{{- if $auditFile }}
+    {
+      "file": {
+        "to-file": {
+          "description": "audit -> /data/openbao/logs, rotated by logrotate",
+          "options": {
+            "file_path": "/data/openbao/logs/audit.log",
+            "mode": "0600"
+          }
+        }
+      }
+    }
+{{- end }}
+  ],
+{{- end }}
   "log_level": "{{ strings.ToUpper $options.log_level }}"
 }

--- a/openbao/rootfs/etc/logrotate.d/openbao-audit
+++ b/openbao/rootfs/etc/logrotate.d/openbao-audit
@@ -1,0 +1,16 @@
+# Rotation for the OpenBao audit sink.
+
+/data/openbao/logs/*.log {
+    daily
+    maxsize 16M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0600 openbao openbao
+    sharedscripts
+    postrotate
+        killall -HUP bao > /dev/null 2>&1 || true
+    endscript
+}

--- a/openbao/rootfs/etc/services.d/logrotate/run
+++ b/openbao/rootfs/etc/services.d/logrotate/run
@@ -1,0 +1,17 @@
+#!/usr/bin/with-contenv bashio
+# Service run scripts must not use errexit — a failed rotation should log and
+# retry, not exit and have s6 restart us in a loop.
+set +e
+
+CONF="/etc/logrotate.d/openbao-audit"
+STATE="/data/openbao/logs/.logrotate.state"
+INTERVAL=3600
+
+bashio::log.info "Audit log rotation active (checking hourly, see ${CONF})."
+
+while true; do
+    sleep "${INTERVAL}"
+    if ! logrotate --state "${STATE}" "${CONF}"; then
+        bashio::log.warning "logrotate exited non-zero — the audit log may be growing unchecked."
+    fi
+done


### PR DESCRIPTION
This PR adds support for audit devices (and optional logrotation) that can be enabled to see who reads which keys when.