### PR TITLE
feat(openbao): Add trusted_proxies and enable prometheus endpoint

### DIFF
--- a/openbao/DOCS.md
+++ b/openbao/DOCS.md
@@ -238,10 +238,6 @@ OpenBao v2.3.2+ **refuses to create audit devices over the API**:
 * cannot enable audit device via API; use declarative, config-based audit device management instead
 ```
 
-So `bao audit enable …` will not work, and neither will Terraform's `vault_audit`
-resource. Audit devices are declared in the server configuration instead, which
-this add-on generates — hence the two options above.
-
 | Option | Sink | Fails closed? |
 | --- | --- | --- |
 | `audit_stdout` | add-on log → journald | No — the `stdout` sink never touches the filesystem |
@@ -256,9 +252,6 @@ the secret.
 
 ## Reverse proxies and client addresses
 
-By default OpenBao records the address it sees on the socket. Behind a reverse proxy that is the
-proxy's address for every request, so the audit log cannot tell callers apart.
-
 Set `trusted_proxies` to the CIDR the proxy connects from — for the Home Assistant traefik add-on
 that is its Docker network, e.g. `172.30.0.0/16` — and OpenBao will trust `X-Forwarded-For` from
 those sources and record the real client instead.
@@ -266,10 +259,6 @@ those sources and record the real client instead.
 **Only set this if the proxy is the only way in.** Any client that can reach the API *directly*
 from a trusted CIDR can forge its own address by setting the header. If the add-on's port is
 published on the host, unpublish it first.
-
-The add-on pins `x_forwarded_for_reject_not_authorized` and `x_forwarded_for_reject_not_present`
-to `false`. Both default to `true` upstream, and left that way a request *without* the header is
-rejected — which would break the add-on's own localhost calls for init, unseal and readiness.
 
 ## Security Notes
 

--- a/openbao/DOCS.md
+++ b/openbao/DOCS.md
@@ -227,6 +227,7 @@ ansible-galaxy collection install community.hashi_vault
 | `tls_disable` | `true` | Disable TLS (use a reverse proxy for encryption) |
 | `audit_stdout` | `true` | Audit log to the add-on log (and therefore journald) |
 | `audit_file` | `false` | Audit log to `/data/openbao/logs/audit.log`, rotated |
+| `trusted_proxies` | `""` | CIDR(s) whose `X-Forwarded-For` header OpenBao will trust |
 | `env_vars` | `[]` | Extra environment variables for the OpenBao process |
 
 ## Audit Logging
@@ -252,6 +253,23 @@ no enabled audit devices can record them"*.
 
 Values in the log are HMAC-SHA256'd — the log shows *which* path was accessed, not
 the secret.
+
+## Reverse proxies and client addresses
+
+By default OpenBao records the address it sees on the socket. Behind a reverse proxy that is the
+proxy's address for every request, so the audit log cannot tell callers apart.
+
+Set `trusted_proxies` to the CIDR the proxy connects from — for the Home Assistant traefik add-on
+that is its Docker network, e.g. `172.30.0.0/16` — and OpenBao will trust `X-Forwarded-For` from
+those sources and record the real client instead.
+
+**Only set this if the proxy is the only way in.** Any client that can reach the API *directly*
+from a trusted CIDR can forge its own address by setting the header. If the add-on's port is
+published on the host, unpublish it first.
+
+The add-on pins `x_forwarded_for_reject_not_authorized` and `x_forwarded_for_reject_not_present`
+to `false`. Both default to `true` upstream, and left that way a request *without* the header is
+rejected — which would break the add-on's own localhost calls for init, unseal and readiness.
 
 ## Security Notes
 

--- a/openbao/config.yaml
+++ b/openbao/config.yaml
@@ -21,6 +21,7 @@ options:
   tls_disable: true
   audit_stdout: true
   audit_file: false
+  trusted_proxies: ""
   env_vars: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
@@ -28,5 +29,6 @@ schema:
   tls_disable: bool
   audit_stdout: bool
   audit_file: bool
+  trusted_proxies: str?
   env_vars:
     - str

--- a/openbao/rootfs/etc/defaults/openbao.json.gotmpl
+++ b/openbao/rootfs/etc/defaults/openbao.json.gotmpl
@@ -1,6 +1,7 @@
 {{- $options := (ds "options") -}}
 {{- $auditStdout := index $options "audit_stdout" -}}
 {{- $auditFile := index $options "audit_file" -}}
+{{- $trustedProxies := index $options "trusted_proxies" -}}
 {
   "ui": true,
   "api_addr": "http{{ if not $options.tls_disable }}s{{ end }}://0.0.0.0:8200",
@@ -13,6 +14,14 @@
         {{ if not $options.tls_disable -}}
         "tls_cert_file": "/ssl/openbao/fullchain.pem",
         "tls_key_file": "/ssl/openbao/privkey.pem",
+        {{ end -}}
+        {{ if $trustedProxies -}}
+        "x_forwarded_for_authorized_addrs": "{{ $trustedProxies }}",
+        {{/* Both default to true upstream. Left true, a request WITHOUT an
+             X-Forwarded-For header is rejected — which would break the add-on's own
+             localhost calls for init, unseal and readiness. Pin them false. */}}
+        "x_forwarded_for_reject_not_authorized": false,
+        "x_forwarded_for_reject_not_present": false,
         {{ end -}}
         "telemetry": {
           "unauthenticated_metrics_access": false

--- a/openbao/rootfs/etc/defaults/openbao.json.gotmpl
+++ b/openbao/rootfs/etc/defaults/openbao.json.gotmpl
@@ -17,9 +17,6 @@
         {{ end -}}
         {{ if $trustedProxies -}}
         "x_forwarded_for_authorized_addrs": "{{ $trustedProxies }}",
-        {{/* Both default to true upstream. Left true, a request WITHOUT an
-             X-Forwarded-For header is rejected — which would break the add-on's own
-             localhost calls for init, unseal and readiness. Pin them false. */}}
         "x_forwarded_for_reject_not_authorized": false,
         "x_forwarded_for_reject_not_present": false,
         {{ end -}}
@@ -62,5 +59,9 @@
 {{- end }}
   ],
 {{- end }}
+  "telemetry": {
+    "prometheus_retention_time": "24h",
+    "disable_hostname": true
+  },
   "log_level": "{{ strings.ToUpper $options.log_level }}"
 }


### PR DESCRIPTION
Adds trusted_proxies to the config so IPs are showing correctly if behind an proxy

(also enable prometheus endpoint)